### PR TITLE
fix: Add country code to wpa_supplicant

### DIFF
--- a/libs/reset_device/static_files/wpa_supplicant.conf.default
+++ b/libs/reset_device/static_files/wpa_supplicant.conf.default
@@ -1,2 +1,3 @@
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
+country=pl


### PR DESCRIPTION
It should help to run the AP on the Raspberry Pi 4 (rpi4).

> On the Raspberry Pi 3B+ and Raspberry Pi 4B, you will also need to set the country code, so that the 5GHz networking can choose the correct frequency bands.

https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md