### PR TITLE
eth: Disable AP host mode if ethernet cable is connected

### DIFF
--- a/libs/reset_device/reset_lib.py
+++ b/libs/reset_device/reset_lib.py
@@ -76,6 +76,9 @@ def is_wifi_active():
 
 	return wifi_active
 
+def is_host_mode():
+	return os.path.isfile('/etc/raspiwifi/host_mode')
+
 def reset_to_host_mode(reboot=True):
 	if not os.path.isfile('/etc/raspiwifi/host_mode'):
 		os.system('aplay /usr/lib/raspiwifi/reset_device/button_chime.wav')
@@ -94,3 +97,12 @@ def reset_to_host_mode(reboot=True):
 		os.system('reboot')
 	else:
 		print('Reseted to host mode. Reboot is required.')
+
+def set_ap_client_mode():
+    os.system('rm -f /etc/raspiwifi/host_mode')
+    os.system('rm /etc/cron.raspiwifi/aphost_bootstrapper')
+    os.system('cp /usr/lib/raspiwifi/reset_device/static_files/apclient_bootstrapper /etc/cron.raspiwifi/')
+    os.system('chmod +x /etc/cron.raspiwifi/apclient_bootstrapper')
+    os.system('mv /etc/dnsmasq.conf.original /etc/dnsmasq.conf')
+    os.system('mv /etc/dhcpcd.conf.original /etc/dhcpcd.conf')
+    os.system('reboot')

--- a/setup_lib.py
+++ b/setup_lib.py
@@ -24,7 +24,7 @@ def copy_configs(wpa_enabled_choice):
 		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/hostapd.conf.wpa /etc/hostapd/hostapd.conf')
 	else:
 		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/hostapd.conf.nowpa /etc/hostapd/hostapd.conf')
-	
+
 	os.system('mv /etc/dhcpcd.conf /etc/dhcpcd.conf.original')
 	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dhcpcd.conf /etc/')
 	os.system('mkdir /etc/cron.raspiwifi')


### PR DESCRIPTION
We detect the `carrier` and decide to disable AP host mode up to
3s after script startup.

If a Wi-Fi is not set up, plug-in the internet cable before startup
to let the connection be established automatically (without enabling
Access Point configuration). Otherwise the Access Point setup will
be enabled. So if you want to use ethernet, don't forget to plug-in
the internet cable before startup always.

After you configure Wi-Fi with Access Point setup, the internet
cable connection should rather be working. But I don't know what
happens if you plug-in cable after booting if the Access Point is
enabled so I recommend to make sure there are no side effects if
you really want to do it.

If needed, to switch to AP Host Mode (WiFi setup), call:

sudo python3 /usr/lib/raspiwifi/reset_device/manual_reset.py