### PR TITLE
configuration_app:advanced: Require SSH password for SSH enabled

### DIFF
--- a/libs/configuration_app/static/stylesheets/app.css
+++ b/libs/configuration_app/static/stylesheets/app.css
@@ -21,6 +21,19 @@ body {
   background-color: #f5f5f5;
 }
 
+details {
+  padding: 1em. 1em 0;
+}
+
+details[open] {
+  padding: .5em;
+}
+
+summary {
+  margin: -.5em -.5em 0;
+  padding: .5em;
+}
+
 #mainContent {
   width: 100%;
   max-width: 330px;

--- a/libs/configuration_app/templates/app.html
+++ b/libs/configuration_app/templates/app.html
@@ -20,10 +20,17 @@
         <label for="wifi_key">Your Wifi password</label>
         <input type="password" name="wifi_key", class="wifiNetworkInputs form-control">
       </div>
-      <div class="form-group">
-        <label for="ssh_enabled">SSH enabled</label>
-        <input type="checkbox" name="ssh_enabled" class="form-control">
-      </div>
+      <details><summary>Advanced (optional)</summary>
+        <div class="form-group">
+          <label for="ssh_enabled">SSH enabled</label>
+          <input type="checkbox" name="ssh_enabled" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="ssh_password">SSH password</label>
+          <input type="password" name="ssh_password" class="form-control">
+          <span>Alphanumerical characters only. If you leave it empty, <b>SSH will be disabled</b>.</span>
+        </div>
+      </details>
       <button type="submit", class="wifiConnectButton btn btn-lg btn-success btn-block">Submit</button>
     </form>
 

--- a/libs/configuration_app/templates/manual_ssid_entry.html
+++ b/libs/configuration_app/templates/manual_ssid_entry.html
@@ -2,7 +2,7 @@
 
 {% block body %}
   <div id="mainContent">
-    
+
     <a href="/"><img class="mb-4" src="{{ url_for('static', filename='one-meter.svg') }}" alt="" width="125" height="125"></a>
     <h1>WiFi Setup</h1>
 
@@ -15,10 +15,17 @@
         <label for="wifi_key">Wifi password</label>
         <input type="password" name="wifi_key", class="wifiNetworkInputs form-control">
       </div>
-      <div class="form-group">
-        <label for="ssh_enabled">SSH enabled</label>
-        <input type="checkbox" name="ssh_enabled" class="form-control">
-      </div>
+      <details><summary>Advanced (optional)</summary>
+        <div class="form-group">
+          <label for="ssh_enabled">SSH enabled</label>
+          <input type="checkbox" name="ssh_enabled" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="ssh_password">SSH password</label>
+          <input type="password" name="ssh_password" class="form-control">
+          <span>Alphanumerical characters only. If you leave it empty, <b>SSH will be disabled</b>.</span>
+        </div>
+      </details>
       <button type="submit" class="wifiConnectButton btn btn-lg btn-success btn-block">Submit</button>
     </form>
 


### PR DESCRIPTION
If `SSH password` is not given or not alphanumerical, SSH is disabled.

**Warning**: `pi` user is assumed.